### PR TITLE
Updating outdated link to Chatdown repoditory

### DIFF
--- a/articles/bot-builder-create-templates.md
+++ b/articles/bot-builder-create-templates.md
@@ -273,6 +273,6 @@ qnamaker create --in qnaKB.json --msbot | msbot connect qna --stdin
 ## References
 - [BotBuilder Tools Source Code](https://github.com/Microsoft/botbuilder-tools)
 - [MSBot](https://github.com/Microsoft/botbuilder-tools/tree/master/MSBot)
-- [ChatDown](https://github.com/Microsoft/botbuilder-tools/tree/master/Chatdown)
+- [ChatDown](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown)
 - [LUDown](https://github.com/Microsoft/botbuilder-tools/tree/master/Ludown)
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)

--- a/articles/bot-builder-tools-az-cli.md
+++ b/articles/bot-builder-tools-az-cli.md
@@ -348,7 +348,7 @@ az bot publish --name "my-bot-name" --resource-group "my-resource-group"
 ## References
 - [BotBuilder Tools Source Code](https://github.com/Microsoft/botbuilder-tools)
 - [MSBot](https://github.com/Microsoft/botbuilder-tools/tree/master/MSBot)
-- [ChatDown](https://github.com/Microsoft/botbuilder-tools/tree/master/Chatdown)
+- [ChatDown](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown)
 - [LUDown](https://github.com/Microsoft/botbuilder-tools/tree/master/ludown)
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 

--- a/articles/bot-service-debug-emulator.md
+++ b/articles/bot-service-debug-emulator.md
@@ -54,7 +54,7 @@ To load transcripts, simply select **File** --> **Open Tranascript File** and se
 
 ## Author transcripts with Chatdown
 
-The [Chatdown](https://github.com/Microsoft/botbuilder-tools/tree/master/Chatdown) tool is a transcript generator which consumes a [markdown](https://daringfireball.net/projects/markdown/syntax) file to generate activity transcripts. You can author your own transcripts completely in markdown format, and save them as a **.chat** file to generate transcripts. This is useful for quickly creating mock conversation scenarios during bot development.  
+The [Chatdown](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown) tool is a transcript generator which consumes a [markdown](https://daringfireball.net/projects/markdown/syntax) file to generate activity transcripts. You can author your own transcripts completely in markdown format, and save them as a **.chat** file to generate transcripts. This is useful for quickly creating mock conversation scenarios during bot development.  
 
 ### Prerequisites
 
@@ -83,7 +83,7 @@ What can I do for you?
 user: Actually nevermind, goodbye.
 bot: bye!
 ```
-[Click here](https://github.com/Microsoft/botbuilder-tools/tree/master/Chatdown/Examples) to view more samples of .chat files. 
+[Click here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown/Examples) to view more samples of .chat files. 
 
 To generate the transcript file, using the **chatdown** command in your CLI, enter the name of the .chat file, followed by '>' and the name of the output transcript file. 
 


### PR DESCRIPTION
This is a PR related to #265 

The URLs in the documentation referencing `Chatdown` are invalid as the directory structure was changed. 
This PR updated the links in the documentation to point to the correct location