### PR TITLE
Updated broken links to sample projects in SDK v3

### DIFF
--- a/articles/bot-builder-tutorial-authentication.md
+++ b/articles/bot-builder-tutorial-authentication.md
@@ -34,10 +34,10 @@ You can extrapolate from the steps in this article to add such features to an ex
 
 | Sample | BotBuilder version | Description |
 |:---|:---:|:---|
-| [AadV1Bot](https://github.com/Microsoft/BotBuilder/tree/master/CSharp/Samples/AadV1Bot) | v3 | Demonstrates OAuthCard support in the v3 C# SDK, using the Azure AD v1 endpoint |
-| [AadV2Bot](https://github.com/Microsoft/BotBuilder/tree/master/CSharp/Samples/AadV2Bot) | v3 |  Demonstrates OAuthCard support in the v3 C# SDK, using the Azure AD v2 endpoint |
-| [GitHubBot](https://github.com/Microsoft/BotBuilder/tree/master/CSharp/Samples/GitHubBot) | v3 |  Demonstrates OAuthCard support in the v3 C# SDK, using GitHub |
-| [BasicOAuth](https://github.com/Microsoft/BotBuilder/tree/master/CSharp/Samples/Microsoft.Bot.Sample.BasicOAuth) | v3 |  Demonstrates OAuth 2.0 support in the v3 C# SDK |
+| [AadV1Bot](https://github.com/Microsoft/BotBuilder-V3/tree/master/CSharp/Samples/AadV1Bot) | v3 | Demonstrates OAuthCard support in the v3 C# SDK, using the Azure AD v1 endpoint |
+| [AadV2Bot](https://github.com/Microsoft/BotBuilder-V3/tree/master/CSharp/Samples/AadV2Bot) | v3 |  Demonstrates OAuthCard support in the v3 C# SDK, using the Azure AD v2 endpoint |
+| [GitHubBot](https://github.com/Microsoft/BotBuilder-V3/tree/master/CSharp/Samples/GitHubBot) | v3 |  Demonstrates OAuthCard support in the v3 C# SDK, using GitHub |
+| [BasicOAuth](https://github.com/Microsoft/BotBuilder-V3/tree/master/CSharp/Samples/Microsoft.Bot.Sample.BasicOAuth) | v3 |  Demonstrates OAuth 2.0 support in the v3 C# SDK |
 
 > [!NOTE]
 > The authentication features also work with Node.js with BotBuilder v3. However, this article covers just sample C# code.


### PR DESCRIPTION
Links on the documentation is having broken links to v3 SDK sample projects. File updated with new locations.