### PR TITLE
Wrongly used MD h2 title at "usage" section

### DIFF
--- a/contributor-guide/article-metadata.md
+++ b/contributor-guide/article-metadata.md
@@ -19,7 +19,7 @@ The standard Bot Framework metadata section looks like this:
   ms.author: <your microsoft alias, one value only, alias only>
 ---
   ```
-##Usage
+## Usage
 
 - The element name and attribute names are case sensitive.
 


### PR DESCRIPTION
Missing a space behind the second # at the "usage" section. The h2 style isn't rendered.
By adding a space behind ## it renders the title as an h2.