### PR TITLE
Add "Dialog Lifecycle" header

### DIFF
--- a/articles/v4sdk/bot-builder-concept-dialog.md
+++ b/articles/v4sdk/bot-builder-concept-dialog.md
@@ -20,6 +20,8 @@ The central concept in the SDK to manage conversations is the idea of a Dialog. 
 
 At runtime, Dialog instances are arranged in a stack. The Dialog on the top of the stack is referred to as the ActiveDialog. The current active Dialog processes the inbound Activity. Between each turn of the conversation (which is not time-bound and may span over several days), the stack is persisted. 
 
+## Dialog Lifecycle
+
 A Dialog implements three main functions:
 - BeginDialog
 - ContinueDialog


### PR DESCRIPTION
The documentation opens with an overview and then flows right into discussing dialog lifecycle. I think adding a header would be a good to break that up and call more attention to the specific topic that is being discussed.