### PR TITLE
Prompt name "workplace" is missing

### DIFF
--- a/articles/v4sdk/bot-builder-prompts.md
+++ b/articles/v4sdk/bot-builder-prompts.md
@@ -291,7 +291,7 @@ Now, our methods include a third step to ask where our user works.
     {
         await stepContext.Context.SendActivityAsync($"Hi {stepContext.Result}!");
 
-        return await stepContext.PromptAsync("name", new PromptOptions { Prompt = MessageFactory.Text("Where do you work?") }, cancellationToken);
+        return await stepContext.PromptAsync("workplace", new PromptOptions { Prompt = MessageFactory.Text("Where do you work?") }, cancellationToken);
     }
 
     private static async Task<DialogTurnResult> SayHiAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)


### PR DESCRIPTION
Prompt name in the sample should be "workplace" instead of "name", there's a prompt name called "name".
Also "workplace" is defined above but never used in C# sample, so it's supposed to be "workplace"