### PR TITLE
Update bot-builder-dotnet-sdk-quickstart.md

### DIFF
--- a/articles/dotnet/bot-builder-dotnet-sdk-quickstart.md
+++ b/articles/dotnet/bot-builder-dotnet-sdk-quickstart.md
@@ -19,7 +19,7 @@ This quickstart walks you through building a bot by using the C# template, and t
 
 ## Prerequisites
 - Visual Studio [2017](https://www.visualstudio.com/downloads)
-- Bot Builder SDK v4 template for [C#](https://botbuilder.myget.org/feed/aitemplates/package/vsix/BotBuilderV4.fbe0fc50-a6f1-4500-82a2-189314b7bea2)
+- Bot Builder SDK v4 template for C#. Install the template by clicking Tools/Extensions & updates, then select "Online and search for "Bot Builder V4"
 - Bot Framework [Emulator](https://github.com/Microsoft/BotFramework-Emulator/releases)
 - Knowledge of [ASP.Net Core](https://docs.microsoft.com/aspnet/core/) and asynchronous programming in [C#](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/index)
 


### PR DESCRIPTION
If you install the VSIX from the link that was proposed, you will get a version that will install in VS2017, but never show up in available templates. This way it works!