### PR TITLE
Update 'md' bash command to 'mkdir'

### DIFF
--- a/articles/javascript/bot-builder-javascript-quickstart.md
+++ b/articles/javascript/bot-builder-javascript-quickstart.md
@@ -42,7 +42,7 @@ To create your bot and initialize its packages
 1. If you don't already have a directory for your JavaScript bots, create one and change directories to it. (We're creating a directory for your JavaScript bots in general, even though we're only creating one bot in this tutorial.)
 
    ```bash
-   md myJsBots
+   mkdir myJsBots
    cd myJsBots
    ```
 


### PR DESCRIPTION
md is not a standard bash command and will error on non-Windows OS's. mkdir works across OS environments.