### PR TITLE
Azure blob storage calling _transcriptStore.GetTranscriptActivitiesAsync results in endless loop

### DIFF
--- a/articles/v4sdk/bot-builder-howto-v4-storage.md
+++ b/articles/v4sdk/bot-builder-howto-v4-storage.md
@@ -592,7 +592,7 @@ public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancel
            var count = 0;
            do
            {
-               var pagedTranscript = await _transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+               var pagedTranscript = await _transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id, continuationToken);
                var activities = pagedTranscript.Items
                   .Where(a => a.Type == ActivityTypes.Message)
                   .Select(ia => (Activity)ia)


### PR DESCRIPTION
I've created the issue in Bot Samples project as well along with the fix that describes issue in details. Please follow:
https://github.com/Microsoft/BotBuilder-Samples/issues/990

The issue has been already merged to master so I think it's good to reflect this in the documentation as well