### PR TITLE
Update JavaScript's method name from C# to JS naming

### DIFF
--- a/articles/v4sdk/bot-builder-howto-send-messages.md
+++ b/articles/v4sdk/bot-builder-howto-send-messages.md
@@ -54,7 +54,7 @@ var responseMessage = turnContext.Activity.Text;
 
 # [JavaScript](#tab/javascript)
 
-In the bot's `OnTurnAsync` method, use the following code to receive a message.
+In the bot's `onTurn` method, use the following code to receive a message.
 
 ```javascript
 let text = turnContext.activity.text;


### PR DESCRIPTION
The JS onTurn method name was using the C# naming in the last code example.