### PR TITLE
typo on kbid key

### DIFF
--- a/articles/v4sdk/bot-builder-howto-qna.md
+++ b/articles/v4sdk/bot-builder-howto-qna.md
@@ -57,7 +57,7 @@ First, add the information required to access your knowledge base including host
     {
       "type": "qna",
       "name": "QnABot",
-      "KbId": "<YOUR_KNOWLEDGE_BASE_ID>",
+      "kbId": "<YOUR_KNOWLEDGE_BASE_ID>",
       "subscriptionKey": "<Your_Azure_Subscription_Key>", // Used when creating your QnA service.
       "endpointKey": "<Your_Recorded_Endpoint_Key>",
       "hostname": "<Your_Recorded_Hostname>",


### PR DESCRIPTION
@msdev there is a small typo in your documentation. "KbId" shoud be "kbid", otherwise it trhows an error 400. In https://bit.ly/2HDc5KH #botbuilder