### PR TITLE
Fix typo in bot quick start article

### DIFF
--- a/articles/bot-service-quickstart.md
+++ b/articles/bot-service-quickstart.md
@@ -129,7 +129,7 @@ You can download the code to work on it locally.
 1. Click on **Download Bot source code** link in the right-pane. 
 1. Follow the prompts to download the code, and then unzip the folder.
 
-The code you downloaded uses an encrypted [.bot file](./v4sdk/bot-file-basics.md). You'll need to update `botFilePath` and `botFileSecret` entires in the appsettings.json or .env file. 
+The code you downloaded uses an encrypted [.bot file](./v4sdk/bot-file-basics.md). You'll need to update `botFilePath` and `botFileSecret` entries in the appsettings.json or .env file. 
 To do that, go to the Azure portal. Select your bot in the portal, then under **App Service Settings** section, click **Application Settings**. In the **Application Settings** pane, you'll 
 see `botFilePath` and `botFileSecret` values. Copy these values and update the .env or appsettings.json file. 
 


### PR DESCRIPTION
In reading quick start guide, I found a small typo.