### PR TITLE
the description for the selection of the LINE plan

### DIFF
--- a/articles/bot-service-channel-connect-line.md
+++ b/articles/bot-service-channel-connect-line.md
@@ -46,6 +46,9 @@ Create a new Messaging API channel by clicking on the green square.
 
 The name cannot include "LINE" or some similar string. Fill out the required fields and confirm your channel settings.
 
+> [!IMPORTANT]
+> When you want to test the LINE channel, you need to select "Developer" Plan. If you select the "FREE" plan, the bot cannot push a message to the LINE account until changing the another plan.
+
 ![LINE screenshot channel settings](./media/channels/LINE-screenshot-4.png)
 
 ## Get necessary values from your channel settings


### PR DESCRIPTION
In "./media/channels/LINE-screenshot-4.png", the "Free" plan is selected.

But the user would need to select the "Developer" plan because the "Free" plan cannot let the bot push a message to the LINE account.

So some user can select the "Free" plan and face the problem that the LINE channel doesn't work.

So I add the IMPORT message.
In addition, I cannot change the image, but the "Developer" plan should be selected in "./media/channels/LINE-screenshot-4.png".