### PR TITLE
Fix incorrect LuisApplication JavaScript code

### DIFF
--- a/articles/v4sdk/bot-builder-howto-v4-luis.md
+++ b/articles/v4sdk/bot-builder-howto-v4-luis.md
@@ -194,7 +194,7 @@ const luisConfig = botConfig.findServiceByNameOrId(LUIS_CONFIGURATION);
 const luisApplication = {
     applicationId: luisConfig.appId,
     endpointKey: luisConfig.subscriptionKey || luisConfig.authoringKey,
-    azureRegion: luisConfig.region
+    endpoint: luisConfig.getEndpoint()
 };
 
 // Create configuration for LuisRecognizer's runtime behavior.


### PR DESCRIPTION
* Content: [Add natural language understanding to your bot - Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js)
* Content Source: [articles/v4sdk/bot-builder-howto-v4-luis.md]

A LuisApplication object has a field called "endpoint", containing the endpoint's domain. This document was using a presumably outdated version, instead setting a field called "azureRegion"