### PR TITLE
Fixed the warning about `--proj-name`

### DIFF
--- a/articles/includes/deploy/snippet-publish.md
+++ b/articles/includes/deploy/snippet-publish.md
@@ -1,13 +1,13 @@
 Publish your local bot to Azure. This step might take a while.
 
 ```cmd
-az bot publish --name <bot-resource-name> --proj-name "<project-file-name>" --resource-group <resource-group-name> --code-dir <directory-path> --verbose --version v4
+az bot publish --name <bot-resource-name> --proj-file-path "<project-file-name>" --resource-group <resource-group-name> --code-dir <directory-path> --verbose --version v4
 ```
 
 | Option | Description |
 |:---|:---|
 | --name | The resource name of the bot in Azure. |
-| --proj-name | For C#, use the startup project file name (without the .csproj) that needs to be published. For example: `EnterpriseBot`. For Node.js, use the main entry point for the bot. For example, `index.js`. |
+| --proj-file-path | For C#, use the startup project file name (without the .csproj) that needs to be published. For example: `EnterpriseBot`. For Node.js, use the main entry point for the bot. For example, `index.js`. |
 | --resource-group | Name of resource group. |
 | --code-dir | The directory to upload bot code from. |
 


### PR DESCRIPTION
Following the warning, use `--proj-file-path` to replace `--proj-name` in the publish command.

Warning info:

> Option '--proj-name' has been deprecated and will be removed in version '2.1.0'. Use '--proj-file-path' instead.