### PR TITLE
Update quickstart-javascript.md

### DIFF
--- a/articles/includes/quickstart-javascript.md
+++ b/articles/includes/quickstart-javascript.md
@@ -14,6 +14,7 @@
 > This call may also hang without exiting if python is already installed on your system:
 
 > ```bash
+> # only run this command if you are on Windows. Read the above note. 
 > npm install -g windows-build-tools
 > ```
 


### PR DESCRIPTION
Adding a short warning to the installation of windows-build-tools.  At the Microsoft OpenHack I saw customers on MacOS running the command without reading the note.