### PR TITLE
Update bot-framework-rest-connector-text-to-speech.md

### DIFF
--- a/articles/rest-api/bot-framework-rest-connector-text-to-speech.md
+++ b/articles/rest-api/bot-framework-rest-connector-text-to-speech.md
@@ -20,9 +20,9 @@ If you are building a bot for a speech-enabled channel such as Cortana, you can 
 
 ## Specify text to be spoken by your bot
 
-To specify text to be spoken by your bot on a speech-enabled channel, set the `speak` property within the [Activity][Activity] object that represents your message. You can set the `speak` property to either a plain text string or a string that is formatted as <a href="https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx" target="_blank">Speech Synthesis Markup Language (SSML)</a>, an XML-based markup language that enables you to control various characteristics of your bot's speech such as voice, rate, volume, pronunciation, pitch, and more. 
+To specify text to be spoken by your bot on a speech-enabled channel, set the `speak` property within the [Activity][Activity] object that represents your message. You can set the `speak` property to either a plain text string or a string that is formatted as <a href="https://www.w3.org/TR/speech-synthesis/" target="_blank">Speech Synthesis Markup Language (SSML)</a>, an XML-based markup language that enables you to control various characteristics of your bot's speech such as voice, rate, volume, pronunciation, pitch, and more. 
 
-The following request sends a message that specifies text to be displayed and text to be spoken and indicates that the bot is [expecting user input](bot-framework-rest-connector-add-input-hints.md). It specifies the `speak` property using <a href="https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx" target="_blank">SSML</a> format to indicate that the word "sure" should be spoken with a moderate amount of emphasis. In this example request, `https://smba.trafficmanager.net/apis` represents the base URI; the base URI for requests that your bot issues may be different. For details about setting the base URI, see [API Reference](bot-framework-rest-connector-api-reference.md#base-uri).
+The following request sends a message that specifies text to be displayed and text to be spoken and indicates that the bot is [expecting user input](bot-framework-rest-connector-add-input-hints.md). It specifies the `speak` property using <a href="https://www.w3.org/TR/speech-synthesis/" target="_blank">SSML</a> format to indicate that the word "sure" should be spoken with a moderate amount of emphasis. In this example request, `https://smba.trafficmanager.net/apis` represents the base URI; the base URI for requests that your bot issues may be different. For details about setting the base URI, see [API Reference](bot-framework-rest-connector-api-reference.md#base-uri).
 
 ```http
 POST https://smba.trafficmanager.net/apis/v3/conversations/abcd1234/activities/5d5cdc723
@@ -46,7 +46,7 @@ Content-Type: application/json
         "name": "recipient's name"
     },
     "text": "Are you sure that you want to cancel this transaction?",
-    "speak": "Are you <emphasis level='moderate'>sure</emphasis> that you want to cancel this transaction?",
+    "speak": "<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\">Are you <emphasis level=\"moderate\">sure</emphasis> that you want to cancel this transaction?</speak>",
     "inputHint": "expectingInput",
     "replyToId": "5d5cdc723"
 }


### PR DESCRIPTION
First, the internal Microsoft link suggests that it's no longer supported. So I propose we link to the W3C spec.  Second, if you use SSML markup, you must include the speak tag. There is no automatic wrapping.