### PR TITLE
Fix trustServiceUrl sample reference

### DIFF
--- a/articles/v4sdk/bot-builder-howto-proactive-message.md
+++ b/articles/v4sdk/bot-builder-howto-proactive-message.md
@@ -118,7 +118,7 @@ MicrosoftAppCredentials.TrustServiceUrl(serviceUrl);
 
 For proactive messaging, `serviceUrl` is the URL of the channel that the recipient of the proactive message is using and can be found in `Activity.ServiceUrl`. 
 
-You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `CreateCallback()` in `ProactiveBot.cs`, but it is commented out because it will not work in Emulator without an `appId` and `appPassword`.
+You'll want to add the above code just prior to the the code that sends the proactive message. In the [Proactive Messages Sample](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/csharp_dotnetcore/16.proactive-messages), you would put it in `NotifyController.cs` just before `await turnContext.SendActivityAsync("proactive hello");`.
 
 # [JavaScript](#tab/javascript)
 
@@ -128,7 +128,7 @@ MicrosoftAppCredentials.trustServiceUrl(serviceUrl);
 
 For proactive messaging, `serviceUrl` is the URL of the channel that the recipient of the proactive message is using and can be found in `activity.serviceUrl`.
 
-You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `completeJob()` in `bot.js`, but it is commented out because it will not work in Emulator without an `appId` and `appPassword`.
+You'll want to add the above code just prior to the the code that sends the proactive message. In the [Proactive Messages Sample](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/16.proactive-messages), you would put it in `index.js` just before `await turnContext.sendActivity('proactive hello');`.
 
 ---
 


### PR DESCRIPTION
The doc was referencing a sample that only existed in a PR that didn't get merged. This PR has it reference the actual sample, correctly.