### PR TITLE
Fixed the QnAEndpointKey name

### DIFF
--- a/articles/v4sdk/bot-builder-howto-qna.md
+++ b/articles/v4sdk/bot-builder-howto-qna.md
@@ -79,7 +79,7 @@ If you aren't deploying this for production, the app ID and password fields can 
   "MicrosoftAppPassword": "",
   
   "QnAKnowledgebaseId": "<knowledge-base-id>",
-  "QnAAuthKey": "<your-endpoint-key>",
+  "QnAEndpointKey": "<your-endpoint-key>",
   "QnAEndpointHostName": "<your-hostname>"
 }
 ```


### PR DESCRIPTION
I have noticed that the sample has it corrected (in QnA.cs) file and in appsettings.json. However, docs have a different name therefore corrected it.