### PR TITLE
added a comma to be consistent

### DIFF
--- a/articles/bot-service-overview-introduction.md
+++ b/articles/bot-service-overview-introduction.md
@@ -14,7 +14,7 @@ ms.date: 05/05/2019
 
 [!INCLUDE [applies-to-both](includes/applies-to-both.md)]
 
-Azure Bot Service and Bot Framework provide tools to build, test, deploy, and manage intelligent bots all in one place. Through the use of modular and extensible framework provided by the SDK, tools, templates, and AI services developers can create bots that use speech, understand natural language, handle questions and answers, and more.
+Azure Bot Service and Bot Framework provide tools to build, test, deploy, and manage intelligent bots, all in one place. Through the use of modular and extensible framework provided by the SDK, tools, templates, and AI services developers can create bots that use speech, understand natural language, handle questions and answers, and more.
 
 ## What is a bot?
 Bots provide an experience that feels less like using a computer and more like dealing with a person - or at least an intelligent robot. They can be used to shift simple, repetitive tasks, such as taking a dinner reservation or gathering profile information, on to automated systems that may no longer require direct human intervention. Users converse with a bot using text, interactive cards, and speech. A bot interaction can be a quick question and answer, or it can be a sophisticated conversation that intelligently provides access to services.


### PR DESCRIPTION
On https://docs.microsoft.com/en-gb/azure/bot-service/?view=azure-bot-service-4.0 there is a comma before "all in one place" but was missing here