### PR TITLE
Typo "**@ColorBot**"→"**\@ColorBot**"

### DIFF
--- a/articles/rest-api/bot-framework-rest-connector-api-reference.md
+++ b/articles/rest-api/bot-framework-rest-connector-api-reference.md
@@ -760,7 +760,7 @@ Defines a user or bot that was mentioned in the conversation.
 | Property | Type | Description |
 |----|----|----|
 | **mentioned** | [ChannelAccount](#channelaccount-object) | A **ChannelAccount** object that specifies the user or the bot that was mentioned. Note that some channels such as Slack assign names per conversation, so it is possible that your bot's mentioned name (in the message's **recipient** property) may be different from the handle that you specified when you [registered](../bot-service-quickstart-registration.md) your bot. However, the account IDs for both would be the same. |
-| **text** | string | The user or bot as mentioned in the conversation. For example, if the message is "@ColorBot pick me a new color," this property would be set to **@ColorBot**. Not all channels set this property. |
+| **text** | string | The user or bot as mentioned in the conversation. For example, if the message is "@ColorBot pick me a new color," this property would be set to **\@ColorBot**. Not all channels set this property. |
 | **type** | string | This object's type. Always set to **Mention**. |
 
 [Back to Schema table](#schema)


### PR DESCRIPTION
Bold with escape characters

https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0