### PR TITLE
Fix bot-builder-webchat-overview.md

### DIFF
--- a/articles/v4sdk/bot-builder-webchat-overview.md
+++ b/articles/v4sdk/bot-builder-webchat-overview.md
@@ -40,9 +40,7 @@ Here is how how you can add a Web Chat control to your website:
                }),
                userID: 'YOUR_USER_ID',
                username: 'Web Chat User',
-               locale: 'en-US',
-               botAvatarInitials: 'WC',
-               userAvatarInitials: 'WW'
+               locale: 'en-US'
             },
             document.getElementById('webchat')
          );


### PR DESCRIPTION
## Summary
This docs should be fixed as well as the following change.

  **[Original docs] microsoft / BotFramework-WebChat - Fix obsolete Web Chat API of Avatar #3553
  https://github.com/microsoft/BotFramework-WebChat/pull/3553**

## Description
botAvatarInitials and userAvatarInitials on [How to use](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-webchat-overview?view=azure-bot-service-4.0#how-to-use) is obsolete API now.

There is no longer the two parameters on [Web Chat API Reference](https://github.com/microsoft/BotFramework-WebChat/blob/master/docs/API.md).

So, it doesn't work.

Meanwhile, it works correctly if I set botAvatarInitials and userAvatarInitials on [styleOptions](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/02.branding-styling-and-customization/a.branding-web-chat#getting-started).

## Specific Changes
I remove botAvatarInitials and userAvatarInitials from Web Chat API parameters on docs.

#### before
```
window.WebChat.renderWebChat(
        {
          directLine: window.WebChat.createDirectLine({
            token: 'YOUR_DIRECT_LINE_TOKEN'
          }),
          userID: 'YOUR_USER_ID',
          username: 'Web Chat User',
          locale: 'en-US',
          botAvatarInitials: 'WC',
          userAvatarInitials: 'WW'
        },
        document.getElementById('webchat')
      );
```

#### after
```
window.WebChat.renderWebChat(
        {
          directLine: window.WebChat.createDirectLine({
            token: 'YOUR_DIRECT_LINE_TOKEN'
          }),
          userID: 'YOUR_USER_ID',
          username: 'Web Chat User',
          locale: 'en-US'
        },
        document.getElementById('webchat')
      );
```

Previously it could be set in the Web Chat API Reference, but it's obsolete now.
It is appropriate to set them in styleOptions now.