### PR TITLE
Bot Framework Composer projects do not need additional steps for DLS

### DIFF
--- a/articles/bot-service-channel-connect-directlinespeech.md
+++ b/articles/bot-service-channel-connect-directlinespeech.md
@@ -59,7 +59,7 @@ With the Direct Line Speech channel connected to your bot, you now need to enabl
 
 1. Click `Save` at the top of the configuration page.
 
-1. The Bot Framework Protocol Streaming Extensions are now enabled for your bot. You are now ready to update your bot code and [integrate Streaming Extensions support](https://aka.ms/botframework/addstreamingprotocolsupport) to an existing bot project.
+1. The Bot Framework Protocol Streaming Extensions are now enabled for your bot. You are now ready to update your bot code and [integrate Streaming Extensions support](https://aka.ms/botframework/addstreamingprotocolsupport) to an existing bot project. If you used the Bot Framework Composer, feel free to skip this step.
 
 ## Adding protocol support to your bot
 


### PR DESCRIPTION
The mention of Streaming Extensions support is confusing for users of Bot Framework Composer. The current listing of steps required feels like it is a mandatory step to get DLS running. In the cast of Bot Framework Composer users, the step does not apply. 