### PR TITLE
State JS code snippets point to unhelpful lines

### DIFF
--- a/articles/v4sdk/bot-builder-howto-v4-state.md
+++ b/articles/v4sdk/bot-builder-howto-v4-state.md
@@ -96,7 +96,7 @@ Next, we register `MemoryStorage` that is used to create `UserState` and `Conver
 Next, we register `MemoryStorage` that is then used to create `UserState` and `ConversationState` objects. These are created in **index.js** and consumed when the bot is created.
 
 **index.js**  
-[!code-javascript[index.js](~/../BotBuilder-Samples/samples/javascript_nodejs/45.state-management/index.js?range=33-39)]
+[!code-javascript[index.js](~/../BotBuilder-Samples/samples/javascript_nodejs/45.state-management/index.js?range=49-56)]
 
 **bots/stateManagementBot.js**  
 [!code-javascript[bot constructor](~/../BotBuilder-Samples/samples/javascript_nodejs/45.state-management/bots/stateManagementBot.js?range=10-12)]


### PR DESCRIPTION
The "Create conversation and user state objects" JS snippet is pointing to a section of code that no longer makes sense. It currently is unhelpful in explaining how to set up state.

Update points to [index.js#L49-L56](https://github.com/microsoft/BotBuilder-Samples/blob/28a039d99221ec6819f08659467363e9bb5913b9/samples/javascript_nodejs/45.state-management/index.js#L49-L56), but I'm not certain whether all of the lines should be included or not.